### PR TITLE
Add email gate before downloading results

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,3 +8,7 @@ Instala las dependencias y lanza la app:
 pip install -r requirements.txt
 streamlit run alquiler_vs_compra_app.py
 ```
+
+Al final del análisis podrás descargar los resultados en CSV. Para habilitar la
+descarga se solicitará que introduzcas tu email. Las direcciones se almacenan
+en el archivo `emails.txt` en la raíz del proyecto.

--- a/alquiler_vs_compra_app.py
+++ b/alquiler_vs_compra_app.py
@@ -373,7 +373,34 @@ elif st.session_state.step == 5:
         "Patrimonio Compra (€)": patrimonio_compra,
         "Inversión Alquiler (€)": inversion_alquiler,
         "Coste Compra (€)": coste_compra_acumulado,
-        "Coste Alquiler (€)": coste_alquiler_acumulado
+        "Coste Alquiler (€)": coste_alquiler_acumulado,
     })
 
-    st.download_button("📥 Descargar resultados como CSV", df_resultados.to_csv(index=False), "alquiler_vs_compra_resultados.csv", "text/csv")
+    if "email_confirmed" not in st.session_state:
+        st.session_state.email_confirmed = False
+
+    st.subheader("📧 Descarga de resultados")
+    if not st.session_state.email_confirmed:
+        email = st.text_input(
+            "Introduce tu email para descargar los resultados",
+            key="email_input",
+        )
+        if st.button("Enviar email", key="send_email"):
+            if email:
+                try:
+                    with open("emails.txt", "a") as f:
+                        f.write(email + "\n")
+                    st.session_state.email_confirmed = True
+                    st.success("Email registrado. Descarga habilitada.")
+                except Exception as e:
+                    st.error(f"Error al guardar el email: {e}")
+            else:
+                st.warning("Por favor ingresa un email válido.")
+
+    if st.session_state.email_confirmed:
+        st.download_button(
+            "📥 Descargar resultados como CSV",
+            df_resultados.to_csv(index=False),
+            "alquiler_vs_compra_resultados.csv",
+            "text/csv",
+        )


### PR DESCRIPTION
## Summary
- ask for user email before allowing download
- log emails to `emails.txt`
- mention new email requirement in the README

## Testing
- `pip install -r requirements.txt`
- `python -m py_compile alquiler_vs_compra_app.py`


------
https://chatgpt.com/codex/tasks/task_e_6874d2c31090832294417a880480514b