### PR TITLE
Add PDF download option

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ streamlit
 numpy-financial
 matplotlib
 numpy
+fpdf


### PR DESCRIPTION
## Summary
- allow PDF export of final results
- add `fpdf` dependency

## Testing
- `pip install -r requirements.txt`
- `python -m py_compile alquiler_vs_compra_app.py`

------
https://chatgpt.com/codex/tasks/task_e_687770f667248322a1c34fcc7a1212c5