### PR TITLE
Add buy-to-rent scenario

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Análisis Alquiler vs Compra 🏠
-Esta app te ayuda a comparar si te conviene más alquilar o comprar una vivienda en función de tus datos.
+Esta app te ayuda a comparar si te conviene más alquilar o comprar una vivienda en función de tus datos. También puedes valorar la rentabilidad de **comprar para alquilar**.
 
 ## Cómo empezar
 Instala las dependencias y lanza la app:


### PR DESCRIPTION
## Summary
- support a third analysis option: buy to rent
- show option in intro and results
- capture rental income and expense inputs
- compute net yield, tax effects and final wealth for rental scenario
- document new buy-to-rent feature in README

## Testing
- `python -m py_compile alquiler_vs_compra_app.py`

------
https://chatgpt.com/codex/tasks/task_e_6887a54bebdc8322bd47b59737d23a8f